### PR TITLE
fix: importing to esm modules without accessing .default property

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,3 +144,4 @@ export class SchemaFactory extends BaseSchema {
 const S = new SchemaFactory()
 
 export default S
+module.exports = S


### PR DESCRIPTION
Thanks for this very useful utility. While using this, I have faced issue in importing this to my esm module based package. I have added a simple fix to take care of the same. This change is backward compatible and should not result in any issues.